### PR TITLE
Add required properties for CycloneDX 1.6

### DIFF
--- a/classes/dependency-track.bbclass
+++ b/classes/dependency-track.bbclass
@@ -31,6 +31,10 @@ python do_dependencytrack_init() {
         "version": 1,
         "metadata": {
             "timestamp": datetime.now().isoformat(),
+            "component": {
+                "type": "operating-system",
+                "name": d.getVar("DISTRO_NAME"),
+            }
         },
         "components": []
     })


### PR DESCRIPTION
`cyclonedx-cli` fails to use the generated file in newer versions because of missing metadata fields.